### PR TITLE
Fix repeated Amber push config prompts and honor disabled push notifications

### DIFF
--- a/lib/logic/notifications_cubit/notifications_cubit.dart
+++ b/lib/logic/notifications_cubit/notifications_cubit.dart
@@ -330,11 +330,16 @@ class NotificationsCubit extends Cubit<NotificationsState> {
   }
 
   void setPushNotifications(String deviceId) {
+    final c = nostrRepository.currentAppCustomization;
+
+    if (!(c?.enablePushNotification ?? false)) {
+      return;
+    }
+
     final kinds = <int>{
       EventKind.DIRECT_MESSAGE,
       EventKind.PRIVATE_DIRECT_MESSAGE,
     };
-    final c = nostrRepository.currentAppCustomization;
 
     if (c?.notifMentionsReplies ?? false) {
       kinds.addAll(

--- a/lib/logic/settings_cubit/settings_cubit.dart
+++ b/lib/logic/settings_cubit/settings_cubit.dart
@@ -9,6 +9,7 @@ import 'package:nostr_core_enhanced/nostr/event_signer/remote_event_signer.dart'
 import 'package:nostr_core_enhanced/nostr/nostr.dart';
 import 'package:nostr_core_enhanced/utils/utils.dart';
 
+import '../../common/notifications/notification_helper.dart';
 import '../../initializers.dart';
 import '../../models/app_client_model.dart';
 import '../../models/app_models/settings_data.dart';
@@ -248,6 +249,8 @@ class SettingsCubit extends Cubit<SettingsState> {
     nc.setSigner(currentSigner);
     currentUserRelayList.pubkey = currentSigner!.getPublicKey();
 
+    NotificationHelper.sharedInstance.resetPushDenialCache();
+
     try {
       nostrRepository.setCurrentAppCustomizationFromCache(broadcast: true);
       nostrRepository.setCurrentUserDraft();
@@ -292,6 +295,8 @@ class SettingsCubit extends Cubit<SettingsState> {
       currentSigner = null;
       nc.setSigner(currentSigner);
       nostrRepository.setCurrentSignerState(null);
+
+      NotificationHelper.sharedInstance.resetPushDenialCache();
       privateKeyIndex = index;
 
       c.call();


### PR DESCRIPTION
Changes: 
- Prevent `setPushNotifications` from configuring push when `enablePushNotification` is false
- Cache Amber signer denial for PUSH_CONFIG to avoid repeated signing requests for the same key/device
- Track last push `deviceId` to skip redundant push config sends
- Reset push‑denial cache on login/logout when signer changes